### PR TITLE
Add downloader cron and plotter

### DIFF
--- a/.github/workflows/download-stats.yml
+++ b/.github/workflows/download-stats.yml
@@ -1,0 +1,26 @@
+on:
+  schedule:
+    - cron: "0 5 * * *"
+
+
+jobs:
+  execute:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Update local files
+        run: ./count_qupath_downloads.sh > "download-stats/$(date -I | sed -e 's/ /-/g').txt"
+
+      - name: Commit files
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git commit -m "Update data" -a
+
+      - name: Push changes
+        uses: ad-m/github-push-action@master
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+

--- a/count_qupath_downloads.sh
+++ b/count_qupath_downloads.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+JSON=$(curl -s https://api.github.com/repos/qupath/qupath/releases)
+SEDQUERY='s/.*: ([0-9]+),/\1/'
+
+for OS in "Mac" "Win" "Linux";
+do
+    echo "QuPath downloads for $OS (full release only): "$(echo $JSON | jq ".[] | select(.prerelease==false) | .assets | .[] | select(.name? | match(\"$OS\"))"  |  grep download_count | sed -E -e "$SEDQUERY" | paste -sd+ | bc)
+done
+echo "Total QuPath downloads: " $(echo $JSON | jq '.[] | select(.prerelease==false)' |  grep download_count | sed -E -e "$SEDQUERY" | paste -sd+ | bc)
+echo "Total QuPath downloads (including pre-release): " $(echo $JSON | jq | grep download_count | sed -E -e "$SEDQUERY" | paste -sd+ | bc)

--- a/download-stats/2025-06-30.txt
+++ b/download-stats/2025-06-30.txt
@@ -1,0 +1,5 @@
+QuPath downloads for Mac (full release only): 191909
+QuPath downloads for Win (full release only): 411591
+QuPath downloads for Linux (full release only): 40782
+Total QuPath downloads:  644282
+Total QuPath downloads (including pre-release):  698031

--- a/plot-download-stats.R
+++ b/plot-download-stats.R
@@ -1,0 +1,30 @@
+library("ggplot2")
+library("readr")
+library("reshape2")
+library("RColorBrewer")
+files <- list.files("download-stats", full.names=TRUE)
+x <- lapply(files, function(f) {
+    ls <- read_lines(f)
+    cs <- strsplit(ls, ": ")
+    out <- lapply(cs, function(l) as.numeric(l[[2]]))
+    names(out) <- sapply(cs, function(x) x[[1]])
+    df <- as.data.frame(out, check.names=FALSE)
+    df$Date <- as.Date(gsub("download-stats/(.*).txt", "\\1", f))
+    df
+})
+
+
+df <- do.call(rbind, x)
+df <- df[, c("Total QuPath downloads")] # filter to just the columns you're interested in...
+
+mdf <- melt(df, id.vars="Date")
+
+ggplot(mdf) +
+    aes(x = Date, y = value, color=variable) +
+    geom_line() +
+    geom_point() +
+    theme_bw() +
+    scale_color_brewer(palette = "Set2", name=NULL) +
+    guides(color=guide_legend(nrow = 2, byrow = TRUE)) +
+    scale_y_continuous(labels = scales::comma, name = "Number of downloads") +
+    theme(legend.position = "bottom")


### PR DESCRIPTION
Output looks like this:

```
QuPath downloads for Mac (full release only): 191909
QuPath downloads for Win (full release only): 411591
QuPath downloads for Linux (full release only): 40782
Total QuPath downloads:  644282
Total QuPath downloads (including pre-release):  698031
```

Files will be titled like "2025-06-30.txt" and should be created daily

Limitation:

> In a public repository, scheduled workflows are automatically disabled when no repository activity has occurred in 60 days. For information on re-enabling a disabled workflow, see [Disabling and enabling a workflow](https://docs.github.com/en/enterprise-server/actions/using-workflows/disabling-and-enabling-a-workflow#enabling-a-workflow).

https://docs.github.com/en/actions/reference/events-that-trigger-workflows#schedule

Unclear if the workflow committing to main makes it a perpetual motion machine... hopefully :)
